### PR TITLE
Refactor api

### DIFF
--- a/osometweet/__init__.py
+++ b/osometweet/__init__.py
@@ -1,1 +1,3 @@
-from osometweet.api import *
+from .api import OsomeTweet
+from .oauth import OAuthHandler, OAuth1a, OAuth2
+from .fields import ObjectExpansions, ObjectFields, ObjectFieldsBase, UserFields, TweetFields, MediaFields, PollFields, PlaceFields

--- a/osometweet/__init__.py
+++ b/osometweet/__init__.py
@@ -1,3 +1,4 @@
 from .api import OsomeTweet
 from .oauth import OAuthHandler, OAuth1a, OAuth2
-from .fields import ObjectExpansions, ObjectFields, ObjectFieldsBase, UserFields, TweetFields, MediaFields, PollFields, PlaceFields
+from .fields import ObjectFields, ObjectFieldsBase, UserFields, TweetFields, MediaFields, PollFields, PlaceFields
+from .expansions import ObjectExpansions, TweetExpansions, UserExpansions

--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -328,29 +328,26 @@ class OsomeTweet:
         else:
             raise ValueError("Invalid type for parameter base_url, must be a string")
             
-    # Tweets
     def tweet_lookup(
             self,
             tids: Union[str, list, tuple],
-            expansions: ObjectExpansions = None,
-            fields: ObjectFields = None
-        ) -> requests.models.Response:
+            fields: ObjectFields = None,
+            expansions: ObjectExpansions = None
+        ) -> dict:
         """
         Looks-up at least one tweet using its tweet id.
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets
  
         Parameters:
             - tids: (str, list, tuple) - Up to 100 unique tweet ids.
+            - fields: (ObjectFields) - additional fields to return. (default = None)
             - expansions: (ObjectExpansions) - Expansions enable requests to
-            expand an ID into a full object in the includes response
-            object. (default = None)
-            - fields: (ObjectFields) - additional fields to return (default = None)
+            expand an ID into a full object in the response. (default = None)
         Returns:
-            requests.models.Response
+            dict
         Raises:
             - Exception
             - ValueError
-
         """
         if isinstance(tids, (str)):
             payload = {"ids": tids}
@@ -379,7 +376,7 @@ class OsomeTweet:
             user_id: str,
             user_fields: Union[list, tuple] = ["id", "name", "username"],
             **kwargs
-        ) -> requests.models.Response:
+        ) -> dict
         """
         Return a list of users who are followers of the specified user ID.
             - Max: 1000 user objects per query
@@ -391,10 +388,8 @@ class OsomeTweet:
             - user_fields (list, tuple) - The user fields included in returned data.
             (Default = "id", "name", "username")
             - kwargs - for optional arguments like "max_results" and "pagination_token"
-
         Returns:
-            requests.models.Response
-
+            dict
         Raises:
             - Exception
             - ValueError
@@ -406,7 +401,7 @@ class OsomeTweet:
             user_id: str,
             user_fields: Union[list, tuple] = ["id", "name", "username"],
             **kwargs
-        ) -> requests.models.Response:
+        ) -> dict:
         """
         Return a list of users the specified user ID is following.
             - Max: 1000 user objects per query
@@ -418,10 +413,8 @@ class OsomeTweet:
             - user_fields (list, tuple) - The user fields included in returned data.
             (Default = "id", "name", "username")
             - kwargs - for optional arguments like "max_results" and "pagination_token"
-
         Returns:
-            requests.models.Response
-
+            dict
         Raises:
             - Exception
             - ValueError
@@ -434,7 +427,7 @@ class OsomeTweet:
             endpoint: str,
             user_fields: Union[list, tuple] = ["id", "name", "username"],
             **kwargs
-        ) -> requests.models.Response:
+        ) -> dict:
         """
         Return a list of users who are followers of or followed by the specified user ID.
             - Max: 1000 user objects per query
@@ -447,10 +440,8 @@ class OsomeTweet:
             (Default = "id", "name", "username")
             - endpoint (str) - valid values are "followers" or "following"
             - kwargs - for optional arguments like "max_results" and "pagination_token"
-
         Returns:
-            requests.models.Response
-
+            dict
         Raises:
             - Exception
             - ValueError
@@ -492,7 +483,8 @@ class OsomeTweet:
     def user_lookup_ids(
             self,
             user_ids: Union[list, tuple],
-            user_fields: Union[list, tuple] = ["id", "name", "username"]
+            fields: ObjectFields = None,
+            expansions: ObjectExpansions = None
         ) -> dict:
         """
         Looks-up user account information using unique user account id numbers.
@@ -503,17 +495,21 @@ class OsomeTweet:
             - user_ids (list, tuple) - unique user ids to include in query (max 100)
             - user_fields (list, tuple) - the user fields included in returned data. 
             (Default = "id", "name", "username")
+            - fields: (ObjectFields) - additional fields to return. (default = None)
+            - expansions: (ObjectExpansions) - Expansions enable requests to
+            expand an ID into a full object in the response. (default = None)
         Returns:
-            - requests.models.Response
+            - dict
         Raises:
             - Exception, ValueError
         """
-        return self._user_lookup(user_ids, "id", user_fields=user_fields)
+        return self._user_lookup(user_ids, "id", fields=fields, expansions=expansions)
 
     def user_lookup_usernames(
             self,
             usernames: Union[list, tuple],
-            user_fields: Union[list, tuple] = ["id", "name", "username"]
+            fields: ObjectFields = None,
+            expansions: ObjectExpansions = None
         ) -> dict:
         """
         Looks-up user account information using account usernames.
@@ -524,8 +520,11 @@ class OsomeTweet:
             - usernames (list, tuple) - usernames to include in query (max 100)
             - user_fields (list, tuple) - the user fields included in returned data. 
             (Default = "id", "name", "username")
+            - fields: (ObjectFields) - additional fields to return. (default = None)
+            - expansions: (ObjectExpansions) - Expansions enable requests to
+            expand an ID into a full object in the response. (default = None)
         Returns:
-            - requests.models.Response
+            - dict
         Raises:
             - Exception, ValueError
         """
@@ -535,13 +534,14 @@ class OsomeTweet:
                 cleaned_usernames.append(username[1:])
             else:
                 cleaned_usernames.append(username)
-        return self._user_lookup(cleaned_usernames, "username", user_fields=user_fields)
+        return self._user_lookup(cleaned_usernames, "username", fields=fields, expansions=expansions)
 
     def _user_lookup(
             self, 
             query: Union[list, tuple], 
             query_type: str,
-            user_fields: Union[list, tuple] = ["id", "name", "username"]
+            fields: ObjectFields = None,
+            expansions: ObjectExpansions = None
         ) -> dict:
         """
         Looks-up user account information using unique user id numbers. 
@@ -552,8 +552,11 @@ class OsomeTweet:
         Parameters:
             - query (list, tuple) - unique user ids or usernames (max 100)
             - query_type (str) - type of the query, can be "id" or "username"
+            - fields: (ObjectFields) - additional fields to return. (default = None)
+            - expansions: (ObjectExpansions) - Expansions enable requests to
+            expand an ID into a full object in the response. (default = None)
         Returns:
-            - requests.models.Response
+            - dict
         Raises:
             - Exception, ValueError
         """

--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -2,301 +2,14 @@ import requests
 import pause
 from typing import Union
 from datetime import datetime
-from requests_oauthlib import OAuth1Session
-import osometweet.utils as o_util
 
-logger = o_util.get_logger(__name__)
+from .oauth import OAuthHandler, OAuth1a, OAuth2
+from .fields import ObjectExpansions, ObjectFields, ObjectFieldsBase, UserFields, TweetFields, MediaFields, PollFields, PlaceFields
 
-#########################################################
-#########################################################
-# Authentication
-#########################################################
-class OAuthHandler:
-    def __init__(self):
-        pass
+from osometweet.utils import get_logger, pause_until
 
-    def make_request(self):
-        pass
+logger = get_logger(__name__)
 
-
-class OAuth1a(OAuthHandler):
-    def __init__(
-        self,
-        api_key: str = "",
-        api_key_secret: str = "",
-        access_token: str = "",
-        access_token_secret = "",
-
-    ) -> None:
-        self._api_key = api_key
-        self._api_key_secret = api_key_secret
-        self._access_token = access_token
-        self._access_token_secret = access_token_secret
-        self._set_oauth_1a_creds()
-
-    def _set_oauth_1a_creds(self) -> None:
-        """
-        Sets the user-based OAuth 1.0a tokens.
-        Ref: https://developer.twitter.com/en/docs/authentication/oauth-1-0a
-
-        Raises:
-            - Exception, ValueError
-        """
-        for key_name in ['api_key', 'api_key_secret', 'access_token', 'access_token_secret']:
-            if not isinstance(getattr(self, '_' + key_name), str):
-                raise ValueError(
-                    f"Invalid type for parameter {key_name}, must be a string."
-                    )
-        # Get oauth object
-        self._oauth_1a = OAuth1Session(
-            self._api_key,
-            client_secret = self._api_key_secret,
-            resource_owner_key = self._access_token,
-            resource_owner_secret = self._access_token_secret
-            )
-
-    def make_request(
-        self,
-        url: str,
-        payload: dict
-       ) -> requests.models.Response:
-        """
-        Method to make the http request to Twitter API
-
-        Parameters:
-            - url (str) - url of the endpoint
-            - payload (dict) - payload of the request
-        Returns:
-            - requests.models.Response
-        """
-        return self._oauth_1a.get(url, params=payload)
-
-
-class OAuth2(OAuthHandler):
-    """
-    Class to handle authenticiation through OAuth 2.0 without user context
-    Only bearer token is required for this class
-    """
-    def __init__(
-        self,
-        bearer_token: str= "",
-    ) -> None:
-        self._bearer_token = bearer_token
-        self._set_bearer_token()
-    
-    # Setters
-    def _set_bearer_token(self) -> None:
-        """
-        Sets the bearer token, which authenticates the user using OAuth 2.0.
-        Ref: https://developer.twitter.com/en/docs/authentication/oauth-2-0/bearer-tokens
-        
-        Raises: 
-            - Exception, ValueError
-        """
-        if isinstance(self._bearer_token, str):
-            self._header = {"Authorization": f"Bearer {self._bearer_token}"}
-        else:
-            raise ValueError(
-                "Invalid type for parameter bearer_token, must be a string"
-            )
-
-    def make_request(
-        self,
-        url: str,
-        payload: dict
-    ) -> requests.models.Response:
-        """
-        Method to make the http request to Twitter API
-
-        Parameters:
-            - url (str) - url of the endpoint
-            - payload (dict) - payload of the request
-        Returns:
-            - requests.models.Response
-        """
-        return requests.get(
-            url,
-            headers=self._header,
-            params=payload
-        )
-
-
-#########################################################
-#########################################################
-# Fields and expansion
-#########################################################
-class ObjectExpansions:
-    avail_expansions = [
-        "attachments.poll_ids", "attachments.media_keys", "author_id",
-        "entities.mentions.username", "geo.place_id", "in_reply_to_user_id",
-        "referenced_tweets.id", "referenced_tweets.id.author_id"
-    ]
-    def __init__(self):
-        self._expansions = self.avail_expansions
-    
-    @property
-    def expansions(self):
-        return self._expansions
-    
-    @expansions.setter
-    def expansions(self, value: Union[list, tuple]):
-        if not isinstance(value, (list,tuple)):
-            raise ValueError(
-                    "Invalid parameter type."
-                    "`expansions` must be a list or tuple."
-                )
-        avail_expansions = set(self.avail_expansions)
-        new_expansions = set(value)
-        valid_new_expansions = list(avail_expansions & new_expansions)
-        invalid_new_expansions = list(new_expansions - (avail_expansions & new_expansions))
-        if invalid_new_expansions:
-            logger.warning(f"{invalid_new_expansions} are not valid expansions and ignored.")
-        self._expansions = valid_new_expansions
-
-    @property
-    def expansions_object(self):
-        return {"expansions": ",".join(self._expansions)}
-
-    def __repr__(self):
-        return ",".join(self.expansions)
-
-
-class ObjectFields:
-    def __init__(self, fields_object=None):
-        self._fields_object = {} if fields_object is None else fields_object
-
-    @property
-    def fields_object(self):
-        return self._fields_object
-    
-    def __add__(self, value: "ObjectFields"):
-        if isinstance(value, ObjectFields):
-            return ObjectFields(fields_object={**self.fields_object, **value.fields_object})
-        else:
-            return self
-    
-    def __radd__(self, value: "ObjectFields"):
-        return self.__add__(value)
-    
-    def __repr__(self):
-        return str(self.fields_object)
-
-
-class ObjectFieldsBase(ObjectFields):
-    default_fields = []
-    optional_fields = []
-    parameter_name = ""
-    def __init__(self, everything: bool = False):
-        self.everything = everything
-        if self.everything:
-            self._fields = self.default_fields + self.optional_fields
-        else:
-            self._fields = self.default_fields
-    
-    @property
-    def fields(self):
-        return self._fields
-    
-    @fields.setter
-    def fields(self, value: Union[list, tuple]):
-        if not isinstance(value, (list,tuple)):
-            raise ValueError(
-                    "Invalid parameter type."
-                    "`fields` must be a list or tuple."
-                )
-        avail_fields = set(self.default_fields + self.optional_fields)
-        new_fields = set(value)
-        valid_new_fields = list(avail_fields & new_fields)
-        invalid_new_fields = list(new_fields - (avail_fields & new_fields))
-        if invalid_new_fields:
-            logger.warning(f"{invalid_new_fields} are not valid fields and ignored.")
-        self._fields = valid_new_fields
-
-    @property
-    def fields_object(self):
-        return {self.parameter_name: ",".join(self._fields)}
-    
-    def __repr__(self):
-        return ",".join(self.fields)
-
-
-class UserFields(ObjectFieldsBase):
-    default_fields = ["id", "name", "username"]
-    optional_fields = [
-        "created_at", "description", "entities", "location",
-        "pinned_tweet_id", "profile_image_url", "protected",
-        "public_metrics", "url", "verified", "withheld"
-    ]
-    parameter_name = "user.fields"
-    def __init__(self, everything: bool = False):
-        super(UserFields, self).__init__(everything=everything)
-
-
-class TweetFields(ObjectFieldsBase):
-    default_fields = ["id", "text"]
-    optional_fields = [
-        "attachments", "author_id", "context_annotations",
-        "conversation_id", "created_at", "entities", "geo",
-        "in_reply_to_user_id", "lang", "possibly_sensitive",
-        "public_metrics", "referenced_tweets", "reply_settings",
-        "source", "withheld"
-    ]
-    # Extra fields only available to the owner of the account
-    extra_fields = [
-        "non_public_metrics", "organic_metrics", "promoted_metrics"
-    ]
-    parameter_name = "tweet.fields"
-    def __init__(self, everything: bool = False):
-        super(TweetFields, self).__init__(everything=everything)
-
-
-class MediaFields(ObjectFieldsBase):
-    default_fields = ["media_key", "type"]
-    optional_fields = [
-        "duration_ms", "height", "preview_image_url",
-        "public_metrics", "width"
-    ]
-    # Extra fields only available to the owner of the account
-    extra_fields = [
-        "non_public_metrics", "organic_metrics", "promoted_metrics"
-    ]
-    parameter_name = "media.fields"
-    def __init__(self, everything: bool = False):
-        super(MediaFields, self).__init__(everything=everything)
-
-
-class PollFields(ObjectFieldsBase):
-    default_fields = ["id", "options"]
-    optional_fields = ["duration_minutes", "end_datetime", "voting_status"]
-    parameter_name = "poll.fields"
-    def __init__(self, everything: bool = False):
-        super(PollFields, self).__init__(everything=everything)
-
-
-class PlaceFields(ObjectFieldsBase):
-    default_fields = ["full_name", "id"]
-    optional_fields = [
-        "contained_within", "country", "country_code",
-        "geo", "name", "place_type"
-    ]
-    parameter_name = "place.fields"
-    def __init__(self, everything: bool = False):
-        super(PlaceFields, self).__init__(everything=everything)
-
-
-def get_all_avail_fields() -> "ObjectFields":
-    return sum([
-        TweetFields(everything=True),
-        UserFields(everything=True),
-        MediaFields(everything=True),
-        PollFields(everything=True),
-        PlaceFields(everything=True)
-    ])
-
-#########################################################
-#########################################################
-# API
-#########################################################
 class OsomeTweet:
     def __init__(
         self,
@@ -376,7 +89,7 @@ class OsomeTweet:
             user_id: str,
             user_fields: Union[list, tuple] = ["id", "name", "username"],
             **kwargs
-        ) -> dict
+        ) -> dict:
         """
         Return a list of users who are followers of the specified user ID.
             - Max: 1000 user objects per query
@@ -573,43 +286,27 @@ class OsomeTweet:
             }
         }.get(query_type)
 
-        available_user_fields = [
-            "created_at", "description", "entities", "id", 
-            "location", "name", "pinned_tweet_id", "profile_image_url", 
-            "protected", "public_metrics", "url", "username", "verified", "withheld"
-        ]
-
         # Check type of query and user_fields 
-        if (isinstance(query, (list, tuple))) and (isinstance(user_fields, (list,tuple))):
-            # Check all provided user fields are in the available set
-            if all([x in available_user_fields for x in user_fields]):
-                # Check no more than 100 ids were passed
-                if len(query) <= 100:
-                    # Update payload.
-                    payload = {
-                    query_specs["parameter_name"]: f"{','.join(query)}",
-                    "user.fields": f"{','.join(user_fields)}"
-                    }
-
-                else:
-                    raise Exception(f"You passed {len(query)} {query_specs['phrase']}. \
-                        This exceeds the maximum for a single query, 100")
-
-            else:
-                raise Exception(
-                    f"Invalid user_field(s) provided. Please make sure \
-                    they are one of the following fields:\n\n \
-                    {print(x) for x in available_user_fields}")
-        else:
+        if not isinstance(query, (list, tuple)):
             raise ValueError(
-            "Invalid parameter type. Both `query` and \
-            `user_fields` must be either a list or tuple."
-                )
+                "Invalid parameter type: `query` must be" "either a list or tuple."
+            )
 
-        # Update payload with any preset parameters
-        # building on top of what may have already been set with 
-        # set_user_fields()
-        payload.update(self._params)
+        # Make sure the query is no longer than 100
+        if len(query) <= 100:
+            # create payload.
+            payload = {
+                query_specs["parameter_name"]: f"{','.join(query)}"
+            }
+        else:
+            raise Exception(f"You passed {len(query)} {query_specs['phrase']}. \
+                This exceeds the maximum for a single query, 100")
+
+        if expansions is not None:
+            payload.update(expansions.expansions_object)
+        # Include fields if present
+        if fields is not None:
+            payload.update(fields.fields_object)
 
         # Pull Data. Wait when necessary and catching time dependent errors.
         switch = True
@@ -629,7 +326,7 @@ class OsomeTweet:
                 buffer_wait_time = 15 
                 resume_time = datetime.fromtimestamp( int(response.headers["x-rate-limit-reset"]) + buffer_wait_time )
                 print(f"Waiting on Twitter.\n\tResume Time: {resume_time}")
-                o_util.pause_until(resume_time)
+                pause_until(resume_time)
 
             # Explicitly checking for time dependent errors.
             # Most of these errors can be solved simply by waiting
@@ -641,21 +338,21 @@ class OsomeTweet:
                     buffer_wait_time = 15 
                     resume_time = datetime.fromtimestamp( int(response.headers["x-rate-limit-reset"]) + buffer_wait_time )
                     print(f"Waiting on Twitter.\n\tResume Time: {resume_time}")
-                    o_util.pause_until(resume_time)
+                    pause_until(resume_time)
 
                 # Twitter internal server error
                 elif response.status_code == 500:
                     # Twitter needs a break, so we wait 30 seconds
                     resume_time = datetime.now().timestamp() + 30
                     print(f"Waiting on Twitter.\n\tResume Time: {resume_time}")
-                    o_util.pause_until(resume_time)
+                    pause_until(resume_time)
 
                 # Twitter service unavailable error
                 elif response.status_code == 503:
                     # Twitter needs a break, so we wait 30 seconds
                     resume_time = datetime.now().timestamp() + 30
                     print(f"Waiting on Twitter.\n\tResume Time: {resume_time}")
-                    o_util.pause_until(resume_time)
+                    pause_until(resume_time)
 
                 # If we get this far, we've done something wrong and should exit
                 raise Exception(

--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -43,11 +43,13 @@ class OsomeTweet:
         else:
             raise ValueError("Invalid type for parameter base_url, must be a string")
             
+    ########################################
+    # Tweet endpoints
     def tweet_lookup(
             self,
             tids: Union[str, list, tuple],
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None
+            expansions: TweetExpansions = None
         ) -> dict:
         """
         Looks-up at least one tweet using its tweet id.
@@ -56,7 +58,7 @@ class OsomeTweet:
         Parameters:
             - tids: (str, list, tuple) - Up to 100 unique tweet ids.
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (TweetExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
         Returns:
             dict
@@ -78,7 +80,7 @@ class OsomeTweet:
         # Set url and update payload with params
         url = f"{self._base_url}/tweets"
         # Include expansions if present
-        if expansions is not None:
+        if expansions is not None and isinstance(expansions, TweetExpansions):
             payload.update(expansions.expansions_object)
         # Include fields if present
         if fields is not None:
@@ -86,11 +88,13 @@ class OsomeTweet:
         response = self._oauth.make_request(url, payload)
         return response.json()
 
+    ########################################
+    # User endpoints
     def get_followers(
             self,
             user_id: str,
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None,
+            expansions: UserExpansions = None,
             **kwargs
         ) -> dict:
         """
@@ -102,7 +106,7 @@ class OsomeTweet:
         Parameters:
             - user_id (str) - Unique user ID to include in the query
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (UserExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
             - kwargs - for optional arguments like "max_results" and "pagination_token"
         Returns:
@@ -117,7 +121,7 @@ class OsomeTweet:
             self,
             user_id: str,
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None,
+            expansions: UserExpansions = None,
             **kwargs
         ) -> dict:
         """
@@ -129,7 +133,7 @@ class OsomeTweet:
         Parameters:
             - user_id (str) - Unique user ID to include in the query
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (UserExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
             - kwargs - for optional arguments like "max_results" and "pagination_token"
         Returns:
@@ -145,7 +149,7 @@ class OsomeTweet:
             user_id: str,
             endpoint: str,
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None,
+            expansions: UserExpansions = None,
             **kwargs
         ) -> dict:
         """
@@ -158,7 +162,7 @@ class OsomeTweet:
             - user_id (str) - Unique user ID to include in the query
             - endpoint (str) - valid values are "followers" or "following"
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (UserExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
             - kwargs - for optional arguments like "max_results" and "pagination_token"
         Returns:
@@ -176,7 +180,8 @@ class OsomeTweet:
         # Create payload.
         payload = dict()
         payload.update(kwargs)
-        if expansions is not None:
+        # Include expansions if present
+        if expansions is not None and isinstance(expansions, UserExpansions):
             payload.update(expansions.expansions_object)
         # Include fields if present
         if fields is not None:
@@ -185,12 +190,11 @@ class OsomeTweet:
         response = self._oauth.make_request(url, payload)
         return response.json()
 
-    # User-Lookup
     def user_lookup_ids(
             self,
             user_ids: Union[list, tuple],
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None
+            expansions: UserExpansions = None
         ) -> dict:
         """
         Looks-up user account information using unique user account id numbers.
@@ -202,7 +206,7 @@ class OsomeTweet:
             - user_fields (list, tuple) - the user fields included in returned data. 
             (Default = "id", "name", "username")
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (UserExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
         Returns:
             - dict
@@ -215,7 +219,7 @@ class OsomeTweet:
             self,
             usernames: Union[list, tuple],
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None
+            expansions: UserExpansions = None
         ) -> dict:
         """
         Looks-up user account information using account usernames.
@@ -227,7 +231,7 @@ class OsomeTweet:
             - user_fields (list, tuple) - the user fields included in returned data. 
             (Default = "id", "name", "username")
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (UserExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
         Returns:
             - dict
@@ -247,7 +251,7 @@ class OsomeTweet:
             query: Union[list, tuple], 
             query_type: str,
             fields: ObjectFields = None,
-            expansions: ObjectExpansions = None
+            expansions: UserExpansions = None
         ) -> dict:
         """
         Looks-up user account information using unique user id numbers. 
@@ -259,7 +263,7 @@ class OsomeTweet:
             - query (list, tuple) - unique user ids or usernames (max 100)
             - query_type (str) - type of the query, can be "id" or "username"
             - fields: (ObjectFields) - additional fields to return. (default = None)
-            - expansions: (ObjectExpansions) - Expansions enable requests to
+            - expansions: (UserExpansions) - Expansions enable requests to
             expand an ID into a full object in the response. (default = None)
         Returns:
             - dict
@@ -295,7 +299,7 @@ class OsomeTweet:
             raise Exception(f"You passed {len(query)} {query_specs['phrase']}. \
                 This exceeds the maximum for a single query, 100")
 
-        if expansions is not None:
+        if expansions is not None and isinstance(expansions, UserExpansions):
             payload.update(expansions.expansions_object)
         # Include fields if present
         if fields is not None:

--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -341,25 +341,10 @@ class OsomeTweet:
  
         Parameters:
             - tids: (str, list, tuple) - Up to 100 unique tweet ids.
-            - expansions: (list, tuple) - Expansions enable requests to
+            - expansions: (ObjectExpansions) - Expansions enable requests to
             expand an ID into a full object in the includes response
             object. (default = None)
-            - media_fields: (list, tuple) - additional fields to return
-            in the media object. The response will contain the selected
-            fields only if a Tweet contains media attachments.(default = None)
-            - place_fields: (list, tuple) - additional fields to return
-            in the place object. The response will contain the selected
-            fields only if location data is present in any of the response
-            objects.(default = None)
-            - poll_fields: (list, tuple) - additional fields to return
-            in the poll object. The response will contain the selected
-            fields only if a Tweet contains a poll.(default = None)
-            - tweet_fields: (list, tuple) - additional fields to return
-            in the Tweet object. By default, `tweet_lookup` enters a
-            value of None which returns the `id` and `text` fields.
-            - user_fields: (list, tuple) - additional fields to return
-            in the user object. User field objects not returned unless
-            explicitly included. (default = None)
+            - fields: (ObjectFields) - additional fields to return (default = None)
         Returns:
             requests.models.Response
         Raises:

--- a/osometweet/expansions.py
+++ b/osometweet/expansions.py
@@ -1,0 +1,52 @@
+from typing import Union
+from osometweet.utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class ObjectExpansions:
+    avail_expansions = []
+    def __init__(self):
+        self._expansions = self.avail_expansions
+
+    @property
+    def expansions(self):
+        return self._expansions
+    
+    @expansions.setter
+    def expansions(self, value: Union[list, tuple]):
+        if not isinstance(value, (list,tuple)):
+            raise ValueError(
+                    "Invalid parameter type."
+                    "`expansions` must be a list or tuple."
+                )
+        avail_expansions = set(self.avail_expansions)
+        new_expansions = set(value)
+        valid_new_expansions = list(avail_expansions & new_expansions)
+        invalid_new_expansions = list(new_expansions - (avail_expansions & new_expansions))
+        if invalid_new_expansions:
+            logger.warning(f"{invalid_new_expansions} are not valid expansions and ignored.")
+        self._expansions = valid_new_expansions
+
+    @property
+    def expansions_object(self):
+        return {"expansions": ",".join(self._expansions)}
+
+    def __repr__(self):
+        return ",".join(self.expansions)
+
+
+class TweetExpansions(ObjectExpansions):
+    avail_expansions = [
+        "attachments.poll_ids", "attachments.media_keys", "author_id",
+        "entities.mentions.username", "geo.place_id", "in_reply_to_user_id",
+        "referenced_tweets.id", "referenced_tweets.id.author_id"
+    ]
+    def __init__(self):
+        super(TweetExpansions, self).__init__()
+
+
+class UserExpansions(ObjectExpansions):
+    avail_expansions = ["pinned_tweet_id"]
+    def __init__(self):
+        super(UserExpansions, self).__init__()

--- a/osometweet/fields.py
+++ b/osometweet/fields.py
@@ -1,0 +1,172 @@
+from typing import Union
+from osometweet.utils import get_logger
+
+logger = get_logger(__name__)
+
+class ObjectExpansions:
+    avail_expansions = [
+        "attachments.poll_ids", "attachments.media_keys", "author_id",
+        "entities.mentions.username", "geo.place_id", "in_reply_to_user_id",
+        "referenced_tweets.id", "referenced_tweets.id.author_id"
+    ]
+    def __init__(self):
+        self._expansions = self.avail_expansions
+    
+    @property
+    def expansions(self):
+        return self._expansions
+    
+    @expansions.setter
+    def expansions(self, value: Union[list, tuple]):
+        if not isinstance(value, (list,tuple)):
+            raise ValueError(
+                    "Invalid parameter type."
+                    "`expansions` must be a list or tuple."
+                )
+        avail_expansions = set(self.avail_expansions)
+        new_expansions = set(value)
+        valid_new_expansions = list(avail_expansions & new_expansions)
+        invalid_new_expansions = list(new_expansions - (avail_expansions & new_expansions))
+        if invalid_new_expansions:
+            logger.warning(f"{invalid_new_expansions} are not valid expansions and ignored.")
+        self._expansions = valid_new_expansions
+
+    @property
+    def expansions_object(self):
+        return {"expansions": ",".join(self._expansions)}
+
+    def __repr__(self):
+        return ",".join(self.expansions)
+
+
+class ObjectFields:
+    def __init__(self, fields_object=None):
+        self._fields_object = {} if fields_object is None else fields_object
+
+    @property
+    def fields_object(self):
+        return self._fields_object
+    
+    def __add__(self, value: "ObjectFields"):
+        if isinstance(value, ObjectFields):
+            return ObjectFields(fields_object={**self.fields_object, **value.fields_object})
+        else:
+            return self
+    
+    def __radd__(self, value: "ObjectFields"):
+        return self.__add__(value)
+    
+    def __repr__(self):
+        return str(self.fields_object)
+
+
+class ObjectFieldsBase(ObjectFields):
+    default_fields = []
+    optional_fields = []
+    parameter_name = ""
+    def __init__(self, everything: bool = False):
+        self.everything = everything
+        if self.everything:
+            self._fields = self.default_fields + self.optional_fields
+        else:
+            self._fields = self.default_fields
+    
+    @property
+    def fields(self):
+        return self._fields
+    
+    @fields.setter
+    def fields(self, value: Union[list, tuple]):
+        if not isinstance(value, (list,tuple)):
+            raise ValueError(
+                    "Invalid parameter type."
+                    "`fields` must be a list or tuple."
+                )
+        avail_fields = set(self.default_fields + self.optional_fields)
+        new_fields = set(value)
+        valid_new_fields = list(avail_fields & new_fields)
+        invalid_new_fields = list(new_fields - (avail_fields & new_fields))
+        if invalid_new_fields:
+            logger.warning(f"{invalid_new_fields} are not valid fields and ignored.")
+        self._fields = valid_new_fields
+
+    @property
+    def fields_object(self):
+        return {self.parameter_name: ",".join(self._fields)}
+    
+    def __repr__(self):
+        return ",".join(self.fields)
+
+
+class UserFields(ObjectFieldsBase):
+    default_fields = ["id", "name", "username"]
+    optional_fields = [
+        "created_at", "description", "entities", "location",
+        "pinned_tweet_id", "profile_image_url", "protected",
+        "public_metrics", "url", "verified", "withheld"
+    ]
+    parameter_name = "user.fields"
+    def __init__(self, everything: bool = False):
+        super(UserFields, self).__init__(everything=everything)
+
+
+class TweetFields(ObjectFieldsBase):
+    default_fields = ["id", "text"]
+    optional_fields = [
+        "attachments", "author_id", "context_annotations",
+        "conversation_id", "created_at", "entities", "geo",
+        "in_reply_to_user_id", "lang", "possibly_sensitive",
+        "public_metrics", "referenced_tweets", "reply_settings",
+        "source", "withheld"
+    ]
+    # Extra fields only available to the owner of the account
+    extra_fields = [
+        "non_public_metrics", "organic_metrics", "promoted_metrics"
+    ]
+    parameter_name = "tweet.fields"
+    def __init__(self, everything: bool = False):
+        super(TweetFields, self).__init__(everything=everything)
+
+
+class MediaFields(ObjectFieldsBase):
+    default_fields = ["media_key", "type"]
+    optional_fields = [
+        "duration_ms", "height", "preview_image_url",
+        "public_metrics", "width"
+    ]
+    # Extra fields only available to the owner of the account
+    extra_fields = [
+        "non_public_metrics", "organic_metrics", "promoted_metrics"
+    ]
+    parameter_name = "media.fields"
+    def __init__(self, everything: bool = False):
+        super(MediaFields, self).__init__(everything=everything)
+
+
+class PollFields(ObjectFieldsBase):
+    default_fields = ["id", "options"]
+    optional_fields = ["duration_minutes", "end_datetime", "voting_status"]
+    parameter_name = "poll.fields"
+    def __init__(self, everything: bool = False):
+        super(PollFields, self).__init__(everything=everything)
+
+
+class PlaceFields(ObjectFieldsBase):
+    default_fields = ["full_name", "id"]
+    optional_fields = [
+        "contained_within", "country", "country_code",
+        "geo", "name", "place_type"
+    ]
+    parameter_name = "place.fields"
+    def __init__(self, everything: bool = False):
+        super(PlaceFields, self).__init__(everything=everything)
+
+
+def get_all_avail_fields() -> "ObjectFields":
+    return sum([
+        TweetFields(everything=True),
+        UserFields(everything=True),
+        MediaFields(everything=True),
+        PollFields(everything=True),
+        PlaceFields(everything=True)
+    ])

--- a/osometweet/fields.py
+++ b/osometweet/fields.py
@@ -3,41 +3,6 @@ from osometweet.utils import get_logger
 
 logger = get_logger(__name__)
 
-class ObjectExpansions:
-    avail_expansions = [
-        "attachments.poll_ids", "attachments.media_keys", "author_id",
-        "entities.mentions.username", "geo.place_id", "in_reply_to_user_id",
-        "referenced_tweets.id", "referenced_tweets.id.author_id"
-    ]
-    def __init__(self):
-        self._expansions = self.avail_expansions
-    
-    @property
-    def expansions(self):
-        return self._expansions
-    
-    @expansions.setter
-    def expansions(self, value: Union[list, tuple]):
-        if not isinstance(value, (list,tuple)):
-            raise ValueError(
-                    "Invalid parameter type."
-                    "`expansions` must be a list or tuple."
-                )
-        avail_expansions = set(self.avail_expansions)
-        new_expansions = set(value)
-        valid_new_expansions = list(avail_expansions & new_expansions)
-        invalid_new_expansions = list(new_expansions - (avail_expansions & new_expansions))
-        if invalid_new_expansions:
-            logger.warning(f"{invalid_new_expansions} are not valid expansions and ignored.")
-        self._expansions = valid_new_expansions
-
-    @property
-    def expansions_object(self):
-        return {"expansions": ",".join(self._expansions)}
-
-    def __repr__(self):
-        return ",".join(self.expansions)
-
 
 class ObjectFields:
     def __init__(self, fields_object=None):

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -1,0 +1,111 @@
+import requests
+from requests_oauthlib import OAuth1Session
+
+class OAuthHandler:
+    def __init__(self):
+        pass
+
+    def make_request(self):
+        pass
+
+
+class OAuth1a(OAuthHandler):
+    def __init__(
+        self,
+        api_key: str = "",
+        api_key_secret: str = "",
+        access_token: str = "",
+        access_token_secret = "",
+
+    ) -> None:
+        self._api_key = api_key
+        self._api_key_secret = api_key_secret
+        self._access_token = access_token
+        self._access_token_secret = access_token_secret
+        self._set_oauth_1a_creds()
+
+    def _set_oauth_1a_creds(self) -> None:
+        """
+        Sets the user-based OAuth 1.0a tokens.
+        Ref: https://developer.twitter.com/en/docs/authentication/oauth-1-0a
+
+        Raises:
+            - Exception, ValueError
+        """
+        for key_name in ['api_key', 'api_key_secret', 'access_token', 'access_token_secret']:
+            if not isinstance(getattr(self, '_' + key_name), str):
+                raise ValueError(
+                    f"Invalid type for parameter {key_name}, must be a string."
+                    )
+        # Get oauth object
+        self._oauth_1a = OAuth1Session(
+            self._api_key,
+            client_secret = self._api_key_secret,
+            resource_owner_key = self._access_token,
+            resource_owner_secret = self._access_token_secret
+            )
+
+    def make_request(
+        self,
+        url: str,
+        payload: dict
+       ) -> requests.models.Response:
+        """
+        Method to make the http request to Twitter API
+
+        Parameters:
+            - url (str) - url of the endpoint
+            - payload (dict) - payload of the request
+        Returns:
+            - requests.models.Response
+        """
+        return self._oauth_1a.get(url, params=payload)
+
+
+class OAuth2(OAuthHandler):
+    """
+    Class to handle authenticiation through OAuth 2.0 without user context
+    Only bearer token is required for this class
+    """
+    def __init__(
+        self,
+        bearer_token: str= "",
+    ) -> None:
+        self._bearer_token = bearer_token
+        self._set_bearer_token()
+    
+    # Setters
+    def _set_bearer_token(self) -> None:
+        """
+        Sets the bearer token, which authenticates the user using OAuth 2.0.
+        Ref: https://developer.twitter.com/en/docs/authentication/oauth-2-0/bearer-tokens
+        
+        Raises: 
+            - Exception, ValueError
+        """
+        if isinstance(self._bearer_token, str):
+            self._header = {"Authorization": f"Bearer {self._bearer_token}"}
+        else:
+            raise ValueError(
+                "Invalid type for parameter bearer_token, must be a string"
+            )
+
+    def make_request(
+        self,
+        url: str,
+        payload: dict
+    ) -> requests.models.Response:
+        """
+        Method to make the http request to Twitter API
+
+        Parameters:
+            - url (str) - url of the endpoint
+            - payload (dict) - payload of the request
+        Returns:
+            - requests.models.Response
+        """
+        return requests.get(
+            url,
+            headers=self._header,
+            params=payload
+        )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,6 +26,7 @@ class TestOauth(unittest.TestCase):
             {"ids": f"{test_tweet_id}"}
             ).json()
         self.assertEqual(resp['data'][0]['id'], test_tweet_id)
+        oauth1a._oauth_1a.close()
     
     def test_1a_exception(self):
         with self.assertRaises(ValueError):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -146,50 +146,6 @@ class TestFields(unittest.TestCase):
         for field in fields_to_request:
             self.assertIn(field, resp['data'][0])
 
-    # def test_rt_media_fields(self):
-    #     """Test return media fields method"""
-    #     correct_fields = [
-    #         "duration_ms",
-    #         "height",
-    #         "media_key",
-    #         "non_public_metrics",
-    #         "organic_metrics",
-    #         "preview_image_url",
-    #         "promoted_metrics",
-    #         "public_metrics",
-    #         "type",
-    #         "width"
-    #     ]
-    #     response = osometweet.utils.ObjectFields.return_media_fields()
-    #     self.assertEqual(response, correct_fields)
-
-    # def test_rt_poll_fields(self):
-    #     """Test return poll fields method"""
-    #     correct_fields = [
-    #         "duration_minutes",
-    #         "end_datetime",
-    #         "id",
-    #         "options",
-    #         "voting_status"
-    #     ]
-    #     response = osometweet.utils.ObjectFields.return_poll_fields()
-    #     self.assertEqual(response, correct_fields)
-
-    # def test_rt_place_fields(self):
-    #     """Test return place fields method"""
-    #     correct_fields = [
-    #         "contained_within",
-    #         "country",
-    #         "country_code",
-    #         "full_name",
-    #         "geo",
-    #         "id",
-    #         "name",
-    #         "place_type",
-    #     ]
-    #     response = osometweet.utils.ObjectFields.return_place_fields()
-    #     self.assertEqual(response, correct_fields)
-
 
 class TestExpansions(unittest.TestCase):
     def setUp(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -119,12 +119,20 @@ class TestFields(unittest.TestCase):
         ]
         user_fields = osometweet.UserFields()
         user_fields.fields = fields_to_request
+
         resp = self.ot.user_lookup_ids(
             ['2244994945'],
             fields=user_fields
             )
         for field in fields_to_request:
             self.assertIn(field, resp['data'][0])
+
+        resp_2 = self.ot.user_lookup_usernames(
+            ['TwitterDev'],
+            fields=user_fields
+            )
+        for field in fields_to_request:
+            self.assertIn(field, resp_2['data'][0])
 
     def test_tweet_fields(self):
         """
@@ -152,11 +160,11 @@ class TestExpansions(unittest.TestCase):
         oauth2 = osometweet.OAuth2(bearer_token=bearer_token)
         self.ot = osometweet.OsomeTweet(oauth2)
     
-    def test_expansions(self):
+    def test_tweet_expansions(self):
         expansions_to_request = [
             "attachments.media_keys", "referenced_tweets.id", "author_id"
         ]
-        expansions = osometweet.ObjectExpansions()
+        expansions = osometweet.TweetExpansions()
         expansions.expansions = expansions_to_request
         resp = self.ot.tweet_lookup(
             ['1212092628029698048'],
@@ -167,6 +175,8 @@ class TestExpansions(unittest.TestCase):
         self.assertIn("media_key", resp["includes"]["media"][0])
         self.assertIn("users", resp["includes"])
         self.assertIn("tweets", resp["includes"])
+
+    # The user expansion can't be tested because the user might not have a pinned tweet
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -106,23 +106,24 @@ class TestFields(unittest.TestCase):
         oauth2 = osometweet.OAuth2(bearer_token=bearer_token)
         self.ot = osometweet.OsomeTweet(oauth2)
 
-    # def test_user_fields(self):
-    #     """
-    #     Test user fields. Test case borrowed from
-    #     https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user
-    #     """
-    #     fields_to_request = [
-    #         "created_at", "description", "entities", "id",
-    #         "location", "name", "pinned_tweet_id", "profile_image_url",
-    #         "protected", "public_metrics", "url", "username",
-    #         "verified", "withheld"
-    #     ]
-    #     user_fields = osometweet.UserFields()
-    #     user_fields.fields = fields_to_request
-    #     resp = self.ot.user_lookup_ids(
-    #         ['2244994945'],
-    #         )
-    #     self.assertEqual(fields, correct_fields)
+    def test_user_fields(self):
+        """
+        Test user fields. Test case borrowed from
+        https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user
+        """
+        fields_to_request = [
+            "created_at", "description", "entities", "id",
+            "location", "name", "pinned_tweet_id", "profile_image_url",
+            "protected", "public_metrics", "url", "username", "verified"
+        ]
+        user_fields = osometweet.UserFields()
+        user_fields.fields = fields_to_request
+        resp = self.ot.user_lookup_ids(
+            ['2244994945'],
+            fields=user_fields
+            )
+        for field in fields_to_request:
+            self.assertIn(field, resp['data'][0])
 
     def test_tweet_fields(self):
         """


### PR DESCRIPTION
Sorry for the large PR. Here are what it inlcudes:

1. Move oauth, fields, expansions to their dedicated py files
2. Create `UserExpansions` and `TweetExpansions` classes
3. Adopt the new fields and expansions model in all endpoints

In my view, the code is much clear now and it will be easier to add new endpoints for the future.