### PR TITLE
Handle rate limits package-wide

### DIFF
--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -12,6 +12,35 @@ class OAuthHandler:
 
 
 class OAuth1a(OAuthHandler):
+    """
+    Class to handle authenticiation through OAuth 1.0a with user context.
+
+    Parameters:
+        - API key (str) : A Twitter API Key string.
+        - API key secret (str) : A Twitter API Key Secret string.
+            Note: Think of these as the user name and password that represents
+                your Twitter developer app when making API requests.
+        - Access token (str) and secret (str) : A Twitter Access Token string.
+        - Access token secret (str) :  A Twitter Access Token Secret string.
+        - manage_rate_limits (bool) : Whether OsomeTweet should handle potential rate
+            limiting errors.
+            - True (default) - Yes, manage my rate limits
+            - False - No, don't manage my rate limits
+
+    Notes:
+        - An access token and access token secret are user-specific
+            credentials used to authenticate OAuth 1.0a API requests. They
+            specify the Twitter account the request is made on behalf of.
+        - You can pair your own Access Token and Access Token Secret strings
+            with your API Key and API Key Secret strings, or you can make
+            requests on behalf of another user. Follow the "Learn about OAuth
+            1.0a" link below to learn more about this.
+        - If you don't have an account, get access here:
+            - https://developer.twitter.com/en/apply-for-access
+        - Learn about OAuth 1.0a authentication here:
+            - https://developer.twitter.com/en/docs/authentication/oauth-1-0a
+
+    """
     def __init__(
         self,
         api_key: str = "",
@@ -80,8 +109,27 @@ class OAuth1a(OAuthHandler):
 
 class OAuth2(OAuthHandler):
     """
-    Class to handle authenticiation through OAuth 2.0 without user context
-    Only bearer token is required for this class
+    Class to handle authenticiation through OAuth 2.0 without user context.
+
+    Parameters:
+        - bearer_token (str) : A bearer token associated with a Twitter developer account.
+        - manage_rate_limits (bool) : Whether OsomeTweet should handle potential rate
+            limiting errors.
+            - True (default) - Yes, manage my rate limits
+            - False - No, don't manage my rate limits
+
+    Notes:
+        - OAuth 2.0 Bearer Tokens authenticate requests on behalf of your developer App.
+            As this method is specific to the App, it does not involve any users. This
+            method is typically for developers that need read-only access to public
+            information. This authentication method requires you pass a Bearer Token with
+            your request, which you can generate within the Keys and tokens section of
+            your developer Apps.
+        - If you don't have an account, get access here:
+            - https://developer.twitter.com/en/apply-for-access
+        - Learn about OAuth 2.0 here:
+            - https://developer.twitter.com/en/docs/authentication/oauth-2-0
+
     """
     def __init__(
         self,

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -1,6 +1,8 @@
 import requests
 from requests_oauthlib import OAuth1Session
 
+from osometweet.rate_limit_manager import manage_rate_limits
+
 class OAuthHandler:
     def __init__(self):
         pass
@@ -15,13 +17,15 @@ class OAuth1a(OAuthHandler):
         api_key: str = "",
         api_key_secret: str = "",
         access_token: str = "",
-        access_token_secret = "",
+        access_token_secret: str = "",
+        manage_rate_limits: bool = True
 
     ) -> None:
         self._api_key = api_key
         self._api_key_secret = api_key_secret
         self._access_token = access_token
         self._access_token_secret = access_token_secret
+        self._manage_rate_limits = manage_rate_limits
         self._set_oauth_1a_creds()
 
     def _set_oauth_1a_creds(self) -> None:
@@ -59,7 +63,19 @@ class OAuth1a(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-        return self._oauth_1a.get(url, params=payload)
+        # Make request
+        response = self._oauth_1a.get(
+            url,
+            params=payload
+            )
+
+        # If requested, manage rate limits
+        if self._manage_rate_limits:
+            response = manage_rate_limits(response)
+        else:
+            pass
+
+        return response
 
 
 class OAuth2(OAuthHandler):
@@ -69,9 +85,11 @@ class OAuth2(OAuthHandler):
     """
     def __init__(
         self,
-        bearer_token: str= "",
+        bearer_token: str = "",
+        manage_rate_limits: bool = True
     ) -> None:
         self._bearer_token = bearer_token
+        self._manage_rate_limits = manage_rate_limits
         self._set_bearer_token()
 
     # Setters
@@ -104,8 +122,16 @@ class OAuth2(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-        return requests.get(
+        response = requests.get(
             url,
             headers=self._header,
             params=payload
-        )
+            )
+
+        # If requested, manage rate limits
+        if self._manage_rate_limits:
+            response = manage_rate_limits(response)
+        else:
+            pass
+
+        return response

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from osometweet.utils import pause_until
+
+def manage_rate_limits(response):
+	"""Manage Twitter V2 Rate Limits
+
+	This method takes in a `requests` response object after querying
+	Twitter and uses the headers["x-rate-limit-remaining"] and
+	headers["x-rate-limit-reset"] headers objects to manage Twitter's
+	most common, time-dependent HTTP errors.
+
+	Wiki Reference: https://github.com/osome-iu/osometweet/wiki/Info:-HTTP-Status-Codes-and-Errors
+	Twitter Reference: https://developer.twitter.com/en/support/twitter-api/error-troubleshooting
+
+	"""
+	while True:
+
+	    # Get number of requests left with our tokens
+	    remaining_requests = int(response.headers["x-rate-limit-remaining"])
+
+	    # If that number is one, we get the reset-time
+	    #   and wait until then, plus 15 seconds (your welcome Twitter).
+	    # The regular 429 exception is caught below as well,
+	    #   however, we want to program defensively, where possible.
+	    if remaining_requests == 1:
+	        buffer_wait_time = 15
+	        resume_time = datetime.fromtimestamp( int(response.headers["x-rate-limit-reset"]) + buffer_wait_time )
+	        print(f"One request from being rate limited. Waiting on Twitter.\n\tResume Time: {resume_time}")
+	        pause_until(resume_time)
+
+	    # Explicitly checking for time dependent errors.
+	    # Most of these errors can be solved simply by waiting
+	    # a little while and pinging Twitter again - so that's what we do.
+	    if response.status_code != 200:
+
+	        # Too many requests error
+	        if response.status_code == 429:
+	            buffer_wait_time = 15
+	            resume_time = datetime.fromtimestamp( int(response.headers["x-rate-limit-reset"]) + buffer_wait_time )
+	            print(f"Too many requests. Waiting on Twitter.\n\tResume Time: {resume_time}")
+	            pause_until(resume_time)
+
+	        # Twitter internal server error
+	        elif response.status_code == 500:
+	            # Twitter needs a break, so we wait 30 seconds
+	            resume_time = datetime.now().timestamp() + 30
+	            print(f"Internal server error @ Twitter. Giving Twitter a break...\n\tResume Time: {resume_time}")
+	            pause_until(resume_time)
+
+	        # Twitter service unavailable error
+	        elif response.status_code == 503:
+	            # Twitter needs a break, so we wait 30 seconds
+	            resume_time = datetime.now().timestamp() + 30
+	            print(f"Twitter service unavailable. Giving Twitter a break...\n\tResume Time: {resume_time}")
+	            pause_until(resume_time)
+
+	        # If we get this far, we've done something wrong and should exit
+	        raise Exception(
+	            "Request returned an error: {} {}".format(
+	                response.status_code, response.text
+	            )
+	        )
+
+	    # Each time we get a 200 response, exit the function and return the response object
+	    if response.ok:
+	        return response


### PR DESCRIPTION
To accomplish this, I refactor the rate-limit-management portion of the old `_user_lookup()` method into the `rate_limit_manager.py` as its own method.

Now, when you authorize an OAuth object, you have an additional parameter that controls whether or not `osometweet` should manage your rate limits, `manage_rate_limits`. You do this in the following way. 

```python
import osometweet
import os 

bearer_token = os.environ.get("TWITTER_BEARER_TOKEN")
oauth = osometweet.OAuth2(
    bearer_token = bearer_token,
    manage_rate_limits = False     # Default = True
)
```
* True = Yes, `osometweet` oh-wise-one, please manage my rate limits
* False = No thank you, `osometweet`, I got this 😎 

> **Above also works for the OAuth1 method**

This boolean is then used in the following way within the `make_request()` `oauth.py` method.
```python
...
...
# Make request
response = self._oauth_1a.get(
    url,
    params=payload
    )

# If requested, manage rate limits
if self._manage_rate_limits:
    response = manage_rate_limits(response)
else:
    pass

return response
```