### PR TITLE
sampled stream functionality

### DIFF
--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -1,10 +1,18 @@
 import requests
 import pause
-from typing import Union
+from typing import Union, Generator
 from datetime import datetime
 
 from .oauth import OAuthHandler
-from .fields import ObjectFields, ObjectFieldsBase, UserFields, TweetFields, MediaFields, PollFields, PlaceFields
+from .fields import (
+    ObjectFields,
+    ObjectFieldsBase,
+    UserFields,
+    TweetFields,
+    MediaFields,
+    PollFields,
+    PlaceFields,
+)
 from .expansions import ObjectExpansions, TweetExpansions, UserExpansions
 
 from osometweet.utils import get_logger, pause_until
@@ -14,9 +22,7 @@ logger = get_logger(__name__)
 
 class OsomeTweet:
     def __init__(
-        self,
-        oauth: OAuthHandler,
-        base_url: str = "https://api.twitter.com/2",
+        self, oauth: OAuthHandler, base_url: str = "https://api.twitter.com/2",
     ) -> None:
         self._oauth = oauth
         # A lot of endpoints can only receive payload paremeters specific
@@ -47,13 +53,13 @@ class OsomeTweet:
             raise ValueError("Invalid type for parameter base_url, must be a string")
 
     def _decorate_payload(
-            self,
-            payload: dict = None,
-            endpoint_type: str = None,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: ObjectExpansions = None
-        ) -> dict:
+        self,
+        payload: dict = None,
+        endpoint_type: str = None,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: ObjectExpansions = None,
+    ) -> dict:
         """
         Method to add fields and expansions to the payload.
         If the `everything` is set to True, then all optional fields and expansions will be returned regardless of the values of `fields` and `expansions`.
@@ -71,20 +77,21 @@ class OsomeTweet:
             payload = dict()
 
         if everything:
-            if endpoint_type == 'user':
-                fields = sum([
-                    TweetFields(everything=True),
-                    UserFields(everything=True)
-                ])
+            if endpoint_type == "user":
+                fields = sum(
+                    [TweetFields(everything=True), UserFields(everything=True)]
+                )
                 expansions = UserExpansions()
-            elif endpoint_type == 'tweet':
-                fields = sum([
-                    TweetFields(everything=True),
-                    UserFields(everything=True),
-                    MediaFields(everything=True),
-                    PollFields(everything=True),
-                    PlaceFields(everything=True)
-                ])
+            elif endpoint_type == "tweet":
+                fields = sum(
+                    [
+                        TweetFields(everything=True),
+                        UserFields(everything=True),
+                        MediaFields(everything=True),
+                        PollFields(everything=True),
+                        PlaceFields(everything=True),
+                    ]
+                )
                 expansions = TweetExpansions()
             else:
                 logger.error("Invalid endpoint type, must be 'user' or 'tweet'.")
@@ -101,12 +108,12 @@ class OsomeTweet:
     ########################################
     # Tweet endpoints
     def tweet_lookup(
-            self,
-            tids: Union[str, list, tuple],
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: TweetExpansions = None
-        ) -> dict:
+        self,
+        tids: Union[str, list, tuple],
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: TweetExpansions = None,
+    ) -> dict:
         """
         Looks-up at least one tweet using its tweet id.
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets
@@ -140,22 +147,22 @@ class OsomeTweet:
         url = f"{self._base_url}/tweets"
         payload = self._decorate_payload(
             payload=payload,
-            endpoint_type='tweet',
+            endpoint_type="tweet",
             everything=everything,
             fields=fields,
-            expansions=expansions
+            expansions=expansions,
         )
         response = self._oauth.make_request(url, payload)
         return response.json()
 
     def get_tweet_timeline(
-            self,
-            user_id: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None,
-            **kwargs
-        ) -> dict:
+        self,
+        user_id: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+        **kwargs,
+    ) -> dict:
         """
         Returns Tweets composed by a single user, specified by the requested user ID.
             - Max: 3200 most recent tweets (using pagination_token)
@@ -202,16 +209,23 @@ class OsomeTweet:
             - Exception
             - ValueError
         """
-        return self._timeline_lookup(user_id, "tweets", everything=everything, fields=fields, expansions=expansions, **kwargs)
+        return self._timeline_lookup(
+            user_id,
+            "tweets",
+            everything=everything,
+            fields=fields,
+            expansions=expansions,
+            **kwargs,
+        )
 
     def get_mentions_timeline(
-            self,
-            user_id: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None,
-            **kwargs
-        ) -> dict:
+        self,
+        user_id: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+        **kwargs,
+    ) -> dict:
         """
         Returns Tweets mentioning a single user specified by the requested user ID.
             - Max: 800 most recent tweets (using pagination_token)
@@ -258,17 +272,24 @@ class OsomeTweet:
             - Exception
             - ValueError
         """
-        return self._timeline_lookup(user_id, "mentions", everything=everything, fields=fields, expansions=expansions, **kwargs)
+        return self._timeline_lookup(
+            user_id,
+            "mentions",
+            everything=everything,
+            fields=fields,
+            expansions=expansions,
+            **kwargs,
+        )
 
     def _timeline_lookup(
-            self,
-            user_id: str,
-            endpoint: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None,
-            **kwargs
-        ) -> dict:
+        self,
+        user_id: str,
+        endpoint: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+        **kwargs,
+    ) -> dict:
         """
         Return tweets sent by (Timeline) or mentioning (Mentions) a specific user ID.
             - Max (Timeline): 3200 most recent tweets (using pagination_token)
@@ -303,10 +324,10 @@ class OsomeTweet:
         url = f"{self._base_url}/users/{user_id}/{endpoint}"
         # Create payload.
         payload = self._decorate_payload(
-            endpoint_type='tweet',
+            endpoint_type="tweet",
             everything=everything,
             fields=fields,
-            expansions=expansions
+            expansions=expansions,
         )
         payload.update(kwargs)
 
@@ -317,13 +338,13 @@ class OsomeTweet:
     ########################################
     # User endpoints
     def get_followers(
-            self,
-            user_id: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None,
-            **kwargs
-        ) -> dict:
+        self,
+        user_id: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+        **kwargs,
+    ) -> dict:
         """
         Return a list of users who are followers of the specified user ID.
             - Max: 1000 user objects per query
@@ -355,16 +376,23 @@ class OsomeTweet:
             - Exception
             - ValueError
         """
-        return self._follows_lookup(user_id, "followers", everything=everything, fields=fields, expansions=expansions, **kwargs)
+        return self._follows_lookup(
+            user_id,
+            "followers",
+            everything=everything,
+            fields=fields,
+            expansions=expansions,
+            **kwargs,
+        )
 
     def get_following(
-            self,
-            user_id: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None,
-            **kwargs
-        ) -> dict:
+        self,
+        user_id: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+        **kwargs,
+    ) -> dict:
         """
         Return a list of users the specified user ID is following.
             - Max: 1000 user objects per query
@@ -396,17 +424,24 @@ class OsomeTweet:
             - Exception
             - ValueError
         """
-        return self._follows_lookup(user_id, "following", everything=everything, fields=fields, expansions=expansions, **kwargs)
+        return self._follows_lookup(
+            user_id,
+            "following",
+            everything=everything,
+            fields=fields,
+            expansions=expansions,
+            **kwargs,
+        )
 
     def _follows_lookup(
-            self,
-            user_id: str,
-            endpoint: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None,
-            **kwargs
-        ) -> dict:
+        self,
+        user_id: str,
+        endpoint: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+        **kwargs,
+    ) -> dict:
         """
         Return a list of users who are followers of or followed by the specified user ID.
             - Max: 1000 user objects per query
@@ -437,10 +472,10 @@ class OsomeTweet:
         url = f"{self._base_url}/users/{user_id}/{endpoint}"
         # Create payload.
         payload = self._decorate_payload(
-            endpoint_type='user',
+            endpoint_type="user",
             everything=everything,
             fields=fields,
-            expansions=expansions
+            expansions=expansions,
         )
         payload.update(kwargs)
 
@@ -448,12 +483,12 @@ class OsomeTweet:
         return response.json()
 
     def user_lookup_ids(
-            self,
-            user_ids: Union[list, tuple],
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None
-        ) -> dict:
+        self,
+        user_ids: Union[list, tuple],
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+    ) -> dict:
         """
         Looks-up user account information using unique user account id numbers.
         User fields included by default match the default parameters returned by Twitter.
@@ -475,15 +510,17 @@ class OsomeTweet:
             - Exception
             - ValueError
         """
-        return self._user_lookup(user_ids, "id", everything=everything, fields=fields, expansions=expansions)
+        return self._user_lookup(
+            user_ids, "id", everything=everything, fields=fields, expansions=expansions
+        )
 
     def user_lookup_usernames(
-            self,
-            usernames: Union[list, tuple],
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None
-        ) -> dict:
+        self,
+        usernames: Union[list, tuple],
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+    ) -> dict:
         """
         Looks-up user account information using account usernames.
         User fields included by default match the default parameters returned by Twitter.
@@ -507,20 +544,26 @@ class OsomeTweet:
         """
         cleaned_usernames = []
         for username in usernames:
-            if username.startswith('@'):
+            if username.startswith("@"):
                 cleaned_usernames.append(username[1:])
             else:
                 cleaned_usernames.append(username)
-        return self._user_lookup(cleaned_usernames, "username", everything=everything, fields=fields, expansions=expansions)
+        return self._user_lookup(
+            cleaned_usernames,
+            "username",
+            everything=everything,
+            fields=fields,
+            expansions=expansions,
+        )
 
     def _user_lookup(
-            self,
-            query: Union[list, tuple],
-            query_type: str,
-            everything: bool = False,
-            fields: ObjectFields = None,
-            expansions: UserExpansions = None
-        ) -> dict:
+        self,
+        query: Union[list, tuple],
+        query_type: str,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+    ) -> dict:
         """
         Looks-up user account information using unique user id numbers.
         User fields included by default match the default parameters from twitter.
@@ -543,16 +586,12 @@ class OsomeTweet:
             - ValueError
         """
         query_specs = {
-            "id": {
-                "phrase": "user ids",
-                "parameter_name": "ids",
-                "endpoint": "users"
-            },
+            "id": {"phrase": "user ids", "parameter_name": "ids", "endpoint": "users"},
             "username": {
                 "phrase": "usernames",
                 "parameter_name": "usernames",
-                "endpoint": "users/by"
-            }
+                "endpoint": "users/by",
+            },
         }.get(query_type)
 
         # Check type of query and user_fields
@@ -564,19 +603,19 @@ class OsomeTweet:
         # Make sure the query is no longer than 100
         if len(query) <= 100:
             # create payload.
-            payload = {
-                query_specs["parameter_name"]: f"{','.join(query)}"
-            }
+            payload = {query_specs["parameter_name"]: f"{','.join(query)}"}
         else:
-            raise Exception(f"You passed {len(query)} {query_specs['phrase']}. \
-                This exceeds the maximum for a single query, 100")
+            raise Exception(
+                f"You passed {len(query)} {query_specs['phrase']}. \
+                This exceeds the maximum for a single query, 100"
+            )
 
         payload = self._decorate_payload(
             payload=payload,
-            endpoint_type='user',
+            endpoint_type="user",
             everything=everything,
             fields=fields,
-            expansions=expansions
+            expansions=expansions,
         )
 
         # Pull Data. Wait when necessary and catching time dependent errors.
@@ -595,7 +634,9 @@ class OsomeTweet:
             #   however, we want to program defensively, where possible.
             if remaining_requests == 1:
                 buffer_wait_time = 15
-                resume_time = datetime.fromtimestamp( int(response.headers["x-rate-limit-reset"]) + buffer_wait_time )
+                resume_time = datetime.fromtimestamp(
+                    int(response.headers["x-rate-limit-reset"]) + buffer_wait_time
+                )
                 print(f"Waiting on Twitter.\n\tResume Time: {resume_time}")
                 pause_until(resume_time)
 
@@ -607,7 +648,9 @@ class OsomeTweet:
                 # Too many requests error
                 if response.status_code == 429:
                     buffer_wait_time = 15
-                    resume_time = datetime.fromtimestamp( int(response.headers["x-rate-limit-reset"]) + buffer_wait_time )
+                    resume_time = datetime.fromtimestamp(
+                        int(response.headers["x-rate-limit-reset"]) + buffer_wait_time
+                    )
                     print(f"Waiting on Twitter.\n\tResume Time: {resume_time}")
                     pause_until(resume_time)
 
@@ -627,11 +670,83 @@ class OsomeTweet:
 
                 # If we get this far, we've done something wrong and should exit
                 raise Exception(
-                    "Request returned an error: {} {}".format(
-                        response.status_code, response.text
-                    )
+                    f"Request returned an error: {response.status_code} {response.text}"
                 )
 
             # Each time we get a 200 response, lets exit the function and return the response.json
             if response.ok:
                 return response.json()
+
+    def sampled_stream(
+        self,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+    ) -> Generator[bytes, None, None]:
+
+        """
+        Streams a random 1% sample of all the tweets.
+        User fields included by default match the default parameters from twitter.
+        Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/sampled-stream/introduction
+
+        Parameters:
+            - everything: (bool) - if True, return all fields and expansions. (default = False)
+            - fields: (ObjectFields) - additional fields to return. (default = None)
+            - expansions: (UserExpansions) - Expansions enable requests to
+            expand an ID into a full object in the response. (default = None)
+        
+        Returns:
+            - Generator
+
+        Raises:
+            - Exception
+        """
+
+        return self._sampled_stream(
+            everything=everything, fields=fields, expansions=expansions
+        )
+
+    def _sampled_stream(
+        self,
+        everything: bool = False,
+        fields: ObjectFields = None,
+        expansions: UserExpansions = None,
+    ) -> Generator[bytes, None, None]:
+        """
+        Streams a random 1% sample of all the tweets.
+        User fields included by default match the default parameters from twitter.
+        Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/sampled-stream/introduction
+
+        Parameters:
+            - everything: (bool) - if True, return all fields and expansions. (default = False)
+            - fields: (ObjectFields) - additional fields to return. (default = None)
+            - expansions: (UserExpansions) - Expansions enable requests to
+            expand an ID into a full object in the response. (default = None)
+        
+        Returns:
+            - Generator
+
+        Raises:
+            - Exception
+        """
+
+        payload = self._decorate_payload(
+            payload=None,
+            endpoint_type="tweet",
+            everything=everything,
+            fields=fields,
+            expansions=expansions,
+        )
+
+        url = f"{self._base_url}/tweets/sample/stream"
+
+        # create a connection to the API that will be used to stream tweets
+        response = self._oauth.make_request(url, payload, stream=True)
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Request returned an error: {response.status_code} {response.text}"
+            )
+        else:
+            # If connection succeeded, return a generator that is used to stream tweets
+            return response.iter_lines()

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -90,7 +90,7 @@ class OAuth2(OAuthHandler):
             )
 
     def make_request(
-        self, url: str, payload: dict, stream: bool = None
+        self, url: str, payload: dict, stream: bool = False
     ) -> requests.models.Response:
         """
         Method to make the http request to Twitter API

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -1,6 +1,7 @@
 import requests
 from requests_oauthlib import OAuth1Session
 
+
 class OAuthHandler:
     def __init__(self):
         pass
@@ -15,8 +16,7 @@ class OAuth1a(OAuthHandler):
         api_key: str = "",
         api_key_secret: str = "",
         access_token: str = "",
-        access_token_secret = "",
-
+        access_token_secret="",
     ) -> None:
         self._api_key = api_key
         self._api_key_secret = api_key_secret
@@ -32,24 +32,25 @@ class OAuth1a(OAuthHandler):
         Raises:
             - Exception, ValueError
         """
-        for key_name in ['api_key', 'api_key_secret', 'access_token', 'access_token_secret']:
-            if not isinstance(getattr(self, '_' + key_name), str):
+        for key_name in [
+            "api_key",
+            "api_key_secret",
+            "access_token",
+            "access_token_secret",
+        ]:
+            if not isinstance(getattr(self, "_" + key_name), str):
                 raise ValueError(
                     f"Invalid type for parameter {key_name}, must be a string."
-                    )
+                )
         # Get oauth object
         self._oauth_1a = OAuth1Session(
             self._api_key,
-            client_secret = self._api_key_secret,
-            resource_owner_key = self._access_token,
-            resource_owner_secret = self._access_token_secret
-            )
+            client_secret=self._api_key_secret,
+            resource_owner_key=self._access_token,
+            resource_owner_secret=self._access_token_secret,
+        )
 
-    def make_request(
-        self,
-        url: str,
-        payload: dict
-       ) -> requests.models.Response:
+    def make_request(self, url: str, payload: dict) -> requests.models.Response:
         """
         Method to make the http request to Twitter API
 
@@ -67,10 +68,8 @@ class OAuth2(OAuthHandler):
     Class to handle authenticiation through OAuth 2.0 without user context
     Only bearer token is required for this class
     """
-    def __init__(
-        self,
-        bearer_token: str= "",
-    ) -> None:
+
+    def __init__(self, bearer_token: str = "",) -> None:
         self._bearer_token = bearer_token
         self._set_bearer_token()
 
@@ -91,9 +90,7 @@ class OAuth2(OAuthHandler):
             )
 
     def make_request(
-        self,
-        url: str,
-        payload: dict
+        self, url: str, payload: dict, stream: bool = None
     ) -> requests.models.Response:
         """
         Method to make the http request to Twitter API
@@ -104,8 +101,5 @@ class OAuth2(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-        return requests.get(
-            url,
-            headers=self._header,
-            params=payload
-        )
+        return requests.get(url, headers=self._header, params=payload, stream=stream)
+


### PR DESCRIPTION
This pull request contains functionality for sampled stream endpoint.

A summary of the modifications contained in this PR are:

- **oauth.py**: modifies OAuth2's _make_request_ parameters and _requests.get_ to add a _stream_ parameter that enables the creation of a streaming connection.

- **api.py**: creates a public interface for _sampled_stream_ endpoint and its corresponding private implementation. These functions are used to establish a connection to the API and to return a generator that is used by the user for streaming purposes.

This endpoint can be tested using the following code:

```
bearer_token = ""
oauth2 = osometweet.OAuth2(bearer_token=bearer_token)
ot = osometweet.OsomeTweet(oauth2)

response = ot.sampled_stream(everything=True)

for tweet in response:
    print(json.loads(tweet))
```

Documentation and tests will follow on a different PR if we are ok with this implementation.