### PR TITLE
Rate-limit manager updates

### DIFF
--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -92,15 +92,30 @@ class OAuth1a(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-        # Make request
-        response = self._oauth_1a.get(
-            url,
-            params=payload
-            )
 
         # If requested, manage rate limits
         if self._manage_rate_limits:
-            response = manage_rate_limits(response)
+            switch = True
+            while switch:
+
+                # Make request
+                response = self._oauth_1a.get(
+                    url,
+                    params=payload
+                    )
+
+                # The below returns:
+                #    True: if there was an error that we waited for,
+                #         ensuring we make the same request again
+                #    False: if there were no errors, so the while-loop breaks
+                switch = manage_rate_limits(response)
+
+        else:
+            # Make request
+            response = self._oauth_1a.get(
+                url,
+                params=payload
+                )
 
         return response
 
@@ -168,14 +183,30 @@ class OAuth2(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-        response = requests.get(
-            url,
-            headers=self._header,
-            params=payload
-            )
-
         # If requested, manage rate limits
         if self._manage_rate_limits:
-            response = manage_rate_limits(response)
+            switch = True
+            while switch:
+
+                # Make request
+                response = requests.get(
+                    url,
+                    headers=self._header,
+                    params=payload
+                    )
+
+                # The below returns:
+                #    True: if there was an error that we waited for,
+                #         ensuring we make the same request again
+                #    False: if there were no errors, so the while-loop breaks
+                switch = manage_rate_limits(response)
+
+        else:
+            # Make request
+            response = requests.get(
+                url,
+                headers=self._header,
+                params=payload
+                )
 
         return response

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -188,13 +188,13 @@ class OAuth2(OAuthHandler):
                 "Invalid type for parameter bearer_token, must be a string"
             )
 
-    def make_request(
+    def _make_one_request(
         self,
         url: str,
         payload: dict
     ) -> requests.models.Response:
         """
-        Method to make the http request to Twitter API
+        Method to make one http request to Twitter API
 
         Parameters:
             - url (str) - url of the endpoint

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -7,8 +7,46 @@ class OAuthHandler:
     def __init__(self):
         pass
 
-    def make_request(self):
-        pass
+    def make_request(
+        self,
+        url: str,
+        payload: dict
+       ) -> requests.models.Response:
+        """
+        Method to make the http request to Twitter API
+
+        Parameters:
+            - url (str) - url of the endpoint
+            - payload (dict) - payload of the request
+        Returns:
+            - requests.models.Response
+        """
+
+        # If requested, manage rate limits
+        if self._manage_rate_limits:
+            switch = True
+            while switch:
+
+                # Make one request
+                response = self._make_one_request(
+                    url,
+                    payload=payload
+                    )
+
+                # The below returns:
+                #    True: if there was an error that we waited for,
+                #         ensuring we make the same request again
+                #    False: if there were no errors, so the while-loop breaks
+                switch = manage_rate_limits(response)
+
+        else:
+            # Make request
+            response = self._make_one_request(
+                url,
+                params=payload
+                )
+
+        return response
 
 
 class OAuth1a(OAuthHandler):
@@ -50,6 +88,7 @@ class OAuth1a(OAuthHandler):
         manage_rate_limits: bool = True
 
     ) -> None:
+        super(OAuth1a, self).__init__()
         self._api_key = api_key
         self._api_key_secret = api_key_secret
         self._access_token = access_token
@@ -78,13 +117,13 @@ class OAuth1a(OAuthHandler):
             resource_owner_secret = self._access_token_secret
             )
 
-    def make_request(
+    def _make_one_request(
         self,
         url: str,
         payload: dict
        ) -> requests.models.Response:
         """
-        Method to make the http request to Twitter API
+        Method to make one http request to Twitter API
 
         Parameters:
             - url (str) - url of the endpoint
@@ -92,31 +131,10 @@ class OAuth1a(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-
-        # If requested, manage rate limits
-        if self._manage_rate_limits:
-            switch = True
-            while switch:
-
-                # Make request
-                response = self._oauth_1a.get(
-                    url,
-                    params=payload
-                    )
-
-                # The below returns:
-                #    True: if there was an error that we waited for,
-                #         ensuring we make the same request again
-                #    False: if there were no errors, so the while-loop breaks
-                switch = manage_rate_limits(response)
-
-        else:
-            # Make request
-            response = self._oauth_1a.get(
-                url,
-                params=payload
-                )
-
+        response = self._oauth_1a.get(
+            url,
+            params=payload
+            )
         return response
 
 
@@ -149,6 +167,7 @@ class OAuth2(OAuthHandler):
         bearer_token: str = "",
         manage_rate_limits: bool = True
     ) -> None:
+        super(OAuth2, self).__init__()
         self._bearer_token = bearer_token
         self._manage_rate_limits = manage_rate_limits
         self._set_bearer_token()
@@ -183,30 +202,9 @@ class OAuth2(OAuthHandler):
         Returns:
             - requests.models.Response
         """
-        # If requested, manage rate limits
-        if self._manage_rate_limits:
-            switch = True
-            while switch:
-
-                # Make request
-                response = requests.get(
-                    url,
-                    headers=self._header,
-                    params=payload
-                    )
-
-                # The below returns:
-                #    True: if there was an error that we waited for,
-                #         ensuring we make the same request again
-                #    False: if there were no errors, so the while-loop breaks
-                switch = manage_rate_limits(response)
-
-        else:
-            # Make request
-            response = requests.get(
-                url,
-                headers=self._header,
-                params=payload
-                )
-
+        response = requests.get(
+            url,
+            headers=self._header,
+            params=payload
+            )
         return response

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -45,9 +45,11 @@ def manage_rate_limits(response):
     # It seems like Twitter's HTTP status code system is also buggy so we need to manually check
     # for the error code no matter what.
     #    Ref: https://twittercommunity.com/t/proper-way-to-handle-rate-limits/150272/5
-    if "errors" in response.json:
+    if "errors" in response.json():
+        # Return the json object so you can see the errors (leave in while we work the quirks out)
+        logger.info(response.json())
 
-        if any([error["code"] == 88 for error in response.json["errors"]]):
+        if any([error["code"] == 88 for error in response.json()["errors"]]):
             logger.info("Too many requests.")
             try:
                 buffer_wait_time = 15


### PR DESCRIPTION
I would appreciate it if either of you could review this relatively soon because it's holding up the superspreaders project. 

Either way, please have a very close look at this because it is basically impossible to test whether or not we will be catching Twitter's HTTP status code bug. That said, the new iteration appears to be functional (I just tested it and it caught the error via `x-rate-limit-remaining` header) and the new while-loop logic in `oauth.py` appears pretty solid as far, as I can tell. 

Changes:
- While-loop logic added to `oauth.py` when `manage_rate_limits = True` (currently the default)
- Updated the conditionals within `rate_limit_manager.py` to try and catch each potential situation.
    - This script now also returns either `True` or `False` triggering the while-loop to continue or break