### PR TITLE
Account for non-error-code errors

### DIFF
--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -86,6 +86,7 @@ def manage_rate_limits(response):
 
         else:
             logger.info("None of those errors were rate-limit errors.")
+            return False
 
 
     # Explicitly checking for time dependent errors.

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -52,7 +52,7 @@ def manage_rate_limits(response):
 
         # Lots of information is returned in the 'errors' object by Twitter
         #   that are not official errors. This removes only those with codes
-        code_message_dict = [dic for dic in response["errors"] if "code" in dic]
+        code_message_dict = [dic for dic in response.json()["errors"] if "code" in dic]
 
         # Create a list of the code integers
         codes = []

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -48,7 +48,7 @@ def manage_rate_limits(response):
     if "errors" in response.json():
         # Return the json object so you can see the errors (leave in while we work the quirks out)
         logger.info("Response JSON contains 'errors' object.")
-        logger.info(response.json()["errors"])
+        #logger.info(response.json()["errors"])
 
         # Lots of information is returned in the 'errors' object by Twitter
         #   that are not official errors. This removes only those with codes

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -56,7 +56,7 @@ def manage_rate_limits(response):
 
         # Create a list of the code integers
         codes = []
-        for dic in error_codes:
+        for dic in code_message_dict:
             codes.extend([val for key,val in dic.items() if key == "code"])
 
         if any([code == 88 for code in codes]):

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -48,7 +48,7 @@ def manage_rate_limits(response):
     if "errors" in response.json():
         # Return the json object so you can see the errors (leave in while we work the quirks out)
         logger.info("Response JSON contains 'errors' object.")
-        logger.info(response.json())
+        logger.info(response.json()["errors"])
 
         # Lots of information is returned in the 'errors' object by Twitter
         #   that are not official errors. This removes only those with codes

--- a/osometweet/rate_limit_manager.py
+++ b/osometweet/rate_limit_manager.py
@@ -47,9 +47,19 @@ def manage_rate_limits(response):
     #    Ref: https://twittercommunity.com/t/proper-way-to-handle-rate-limits/150272/5
     if "errors" in response.json():
         # Return the json object so you can see the errors (leave in while we work the quirks out)
+        logger.info("Response JSON contains 'errors' object.")
         logger.info(response.json())
 
-        if any([error["code"] == 88 for error in response.json()["errors"]]):
+        # Lots of information is returned in the 'errors' object by Twitter
+        #   that are not official errors. This removes only those with codes
+        code_message_dict = [dic for dic in response["errors"] if "code" in dic]
+
+        # Create a list of the code integers
+        codes = []
+        for dic in error_codes:
+            codes.extend([val for key,val in dic.items() if key == "code"])
+
+        if any([code == 88 for code in codes]):
             logger.info("Too many requests.")
             try:
                 buffer_wait_time = 15
@@ -73,6 +83,9 @@ def manage_rate_limits(response):
                     "Tried waiting some period of time but there appears to be another error!!",
                     "To avoid potential suspension due to ignoring rate limit warnings, we break the program."
                     )
+
+        else:
+            logger.info("None of those errors were rate-limit errors.")
 
 
     # Explicitly checking for time dependent errors.
@@ -122,6 +135,5 @@ def manage_rate_limits(response):
                 )
             )
 
-    # Each time we get a 200 response, exit the function and return False to break the while-loop
-    if response.ok:
-        return False
+    # If we get this far, we should be error-free
+    return False


### PR DESCRIPTION
I have learned that Twitter sometimes returns other non-error-code type errors in the `response["errors"]` object of a response. For example, something like the below

```python
[{'parameter': 'entities.mentions.username',
  'resource_id': 'KeishaJake',
  'value': 'KeishaJake',
  'detail': 'User has been suspended: [KeishaJake].',
  'title': 'Forbidden',
  'resource_type': 'user',
  'type': 'https://api.twitter.com/2/problems/resource-not-found'},
 {'parameter': 'entities.mentions.username',
  'resource_id': 'MolonlabeBernie',
  'value': 'MolonlabeBernie',
  'detail': 'User has been suspended: [MolonlabeBernie].',
  'title': 'Forbidden',
  'resource_type': 'user',
  'type': 'https://api.twitter.com/2/problems/resource-not-found'}]
```

As a result, the previous code would throw an error when legitimate data was returned b/c it caught the `response["errors"]` object but couldn't find the "code" key in `response["errors"]`. 

The new block handles this. 

I also removed the, if `response.ok` conditional because it seems redundant and I'm not confident that Twitter will return this properly anyway. If we avoid all of the other conditionals, I think we should be okay. 