### PR TITLE
Generalizes make_request to enable handling different HTTP request me…

### DIFF
--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -245,7 +245,7 @@ class OsomeTweet:
         # Add kwargs
         payload.update(kwargs)
 
-        response = self._oauth.make_request(url, payload)
+        response = self._oauth.make_request('GET', url, payload)
         return response.json()
 
     ########################################
@@ -298,7 +298,7 @@ class OsomeTweet:
             expansions=expansions
         )
 
-        response = self._oauth.make_request(url, payload)
+        response = self._oauth.make_request('GET', url, payload)
         return response.json()
 
     def get_tweet_timeline(
@@ -465,7 +465,7 @@ class OsomeTweet:
         )
         payload.update(kwargs)
 
-        response = self._oauth.make_request(url, payload)
+        response = self._oauth.make_request('GET', url, payload)
         return response.json()
 
     ########################################
@@ -602,7 +602,7 @@ class OsomeTweet:
         )
         payload.update(kwargs)
 
-        response = self._oauth.make_request(url, payload)
+        response = self._oauth.make_request('GET', url, payload)
         return response.json()
 
     def user_lookup_ids(
@@ -742,5 +742,5 @@ class OsomeTweet:
 
         url = f"{self._base_url}/{query_specs['endpoint']}"
 
-        response = self._oauth.make_request(url, payload)
+        response = self._oauth.make_request('GET', url, payload)
         return response.json()

--- a/osometweet/oauth.py
+++ b/osometweet/oauth.py
@@ -9,13 +9,15 @@ class OAuthHandler:
 
     def make_request(
         self,
+        method: str,
         url: str,
         payload: dict
        ) -> requests.models.Response:
         """
-        Method to make the http request to Twitter API
+        Method to make the HTTP request to Twitter API
 
         Parameters:
+            - method (str) - HTTP request method
             - url (str) - url of the endpoint
             - payload (dict) - payload of the request
         Returns:
@@ -29,6 +31,7 @@ class OAuthHandler:
 
                 # Make one request
                 response = self._make_one_request(
+                    method,
                     url,
                     payload=payload
                     )
@@ -42,8 +45,9 @@ class OAuthHandler:
         else:
             # Make request
             response = self._make_one_request(
+                method,
                 url,
-                params=payload
+                payload=payload
                 )
 
         return response
@@ -119,22 +123,30 @@ class OAuth1a(OAuthHandler):
 
     def _make_one_request(
         self,
+        method: str,
         url: str,
         payload: dict
        ) -> requests.models.Response:
         """
-        Method to make one http request to Twitter API
+        Method to make one HTTP request to Twitter API
 
         Parameters:
+            - method (str) - HTTP request method
             - url (str) - url of the endpoint
             - payload (dict) - payload of the request
         Returns:
             - requests.models.Response
         """
-        response = self._oauth_1a.get(
-            url,
-            params=payload
-            )
+        if method.upper() == 'GET':
+            response = self._oauth_1a.get(
+                url,
+                params=payload
+                )
+        elif method.upper() == 'POST':
+            response = self._oauth_1a.post(
+                url,
+                params=payload
+                )            
         return response
 
 
@@ -190,19 +202,22 @@ class OAuth2(OAuthHandler):
 
     def _make_one_request(
         self,
+        method: str,
         url: str,
         payload: dict
     ) -> requests.models.Response:
         """
-        Method to make one http request to Twitter API
+        Method to make one HTTP request to Twitter API
 
         Parameters:
+            - method (str) - HTTP request method
             - url (str) - url of the endpoint
             - payload (dict) - payload of the request
         Returns:
             - requests.models.Response
         """
-        response = requests.get(
+        response = requests.request(
+            method,
             url,
             headers=self._header,
             params=payload

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,11 +7,11 @@ This folder contains the unit tests for the package.
 You will need a set of valid Twitter developer app keys for the V2 API, export the keys and secrets using the following commands:
 
 ```sh
-export 'API_KEY'='YOUR_TWITTER_API_KEY'
-export 'API_KEY_SECRET'='YOUR_TWITTER_API_KEY_SECRET'
-export 'ACCESS_TOKEN'='YOUR_TWITTER_ACCESS_TOKEN'
-export 'ACCESS_TOKEN_SECRET'='YOUR_TWITTER_ACCESS_TOKEN_SECRET'
-export 'BEARER_TOKEN'='YOUR_TWITTER_BEARER_TOKEN'
+export 'TWITTER_API_KEY'='YOUR_TWITTER_API_KEY'
+export 'TWITTER_API_KEY_SECRET'='YOUR_TWITTER_API_KEY_SECRET'
+export 'TWITTER_ACCESS_TOKEN'='YOUR_TWITTER_ACCESS_TOKEN'
+export 'TWITTER_ACCESS_TOKEN_SECRET'='YOUR_TWITTER_ACCESS_TOKEN_SECRET'
+export 'TWITTER_BEARER_TOKEN'='YOUR_TWITTER_BEARER_TOKEN'
 ```
 
 Then just run:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,7 +7,7 @@ api_key = os.environ.get('TWITTER_API_KEY', '')
 api_key_secret = os.environ.get('TWITTER_API_KEY_SECRET', '')
 access_token = os.environ.get('TWITTER_ACCESS_TOKEN', '')
 access_token_secret = os.environ.get('TWITTER_ACCESS_TOKEN_SECRET', '')
-bearer_token = os.environ.get("TWITTER_BEARER_TOKEN")
+bearer_token = os.environ.get('TWITTER_BEARER_TOKEN', '')
 
 class TestOauth(unittest.TestCase):
     """
@@ -22,6 +22,7 @@ class TestOauth(unittest.TestCase):
         )
         test_tweet_id = '1323314485705297926'
         resp = oauth1a.make_request(
+            'GET',
             'https://api.twitter.com/2/tweets',
             {"ids": f"{test_tweet_id}"}
             ).json()
@@ -42,6 +43,7 @@ class TestOauth(unittest.TestCase):
         oauth2 = osometweet.OAuth2(bearer_token=bearer_token)
         test_tweet_id = '1323314485705297926'
         resp = oauth2.make_request(
+            'GET',
             'https://api.twitter.com/2/tweets',
             {"ids": f"{test_tweet_id}"}
             ).json()


### PR DESCRIPTION
Addresses issue #61, which is required to implement the streams.

- Generalizes make_request to enable handling different HTTP request method as needed by new endpoints
- Fixes bug in OAuthHandler.make_request where incorrect parameter in the else's _make_one_request call was used
- Updates the test suite to reflect changes made to make_request
- Fixes the env variables in test.README.md to match the names used in test.py

All the test in the test suite passed.