### PR TITLE
Add utility function that creates Twitter-friendly time strings for queries

### DIFF
--- a/osometweet/utils.py
+++ b/osometweet/utils.py
@@ -28,9 +28,15 @@ def get_logger(name):
 
 
 def pause_until(time):
-    """ Pause your program until a specific end time. 'time' is either
-    a valid datetime object or unix timestamp in seconds (i.e. seconds
-    since Unix epoch) """
+    """
+    Pause your program until a specific time, specified with `time`.
+
+    Parameters:
+        - time (datetime or unix timestamp) : pause until this time
+
+    Exceptions:
+        Exception
+    """
     end = time
 
     # Convert datetime to unix timestamp and adjust for locality
@@ -52,9 +58,7 @@ def pause_until(time):
         now = pytime.time()
         diff = end - now
 
-        #
         # Time is up!
-        #
         if diff <= 0:
             break
         else:
@@ -63,23 +67,98 @@ def pause_until(time):
 
 
 def chunker(seq: list, size: int) -> list:
-    """ Turns a list (seq) into a list of
-    smaller lists len <= size, where only the
+    """
+    Convert a list (seq) into a list of
+    smaller lists (with len <= size), where only the
     last list will have len < size.
 
-    :param iterable seq
-    :param int size
+    Parameters:
+        - seq (list) : the iterable you'd like to chunk into
+            smaller lists
+        - size (int) : the size of the returned chunk(s)
 
-    return list
+    Return:
+        - list
+
+    Exceptions:
+        - ValueError
     ~~~
 
     Example Usage:
 
-        import osometweet.utils as o_utils
+    import osometweet.utils as o_utils
     my_list = [1,2,3,4,5,6,7,8,9]
+
     o_utils.chunker(seq = my_list, size = 2)
+
+    # Returns
     [[1, 2], [3, 4], [5, 6], [7, 8], [9]]
     """
-    if isinstance(seq, list) == False:
+    if not isinstance(seq, list):
         raise ValueError("`seq` must be a list")
     return list(seq[pos:pos + size] for pos in range(0, len(seq), size))
+
+def convert_date_to_iso(time_string:str, time_format="%Y-%m-%d") -> str:
+    """
+    Convert input `time_string` to the iso format that Twitter
+    requires for queries (ISO 8601/RFC 3339). Output times are
+    all returned in UTC time format.
+
+    Parameters:
+        - time_string (str): a string representation of time that should
+            match the `time_format`
+        - time_format (str): the datetime format code of `time_string`.
+            Default `time_format` = "%Y-%m-%d", where:
+                - %Y = Year with century as a decimal number (e.g. 2020)
+                - %m = Month as a zero-padded decimal number (e.g. 07 for July)
+                - %d = Day of the month as a zero-padded decimal number
+                    (e.g., 01 for the first day of the month)
+                - Assumes hour, minute, and second all equal zero
+
+    Return:
+        - str
+
+    Exceptions:
+        - TypeError
+        - ValueError
+    ~~~
+
+    Examples:
+
+    # Load utils
+    import osometweet.utils as o_utils
+
+    ### 1. Default usage
+    o_utils.convert_date_to_iso("2020-01-01")
+
+    # Returns
+    '2020-01-01T00:00:00Z'
+
+    ** Note that we don't specify the hour, minute,
+    or seconds and the function fills in this
+    information for us. **
+
+
+    ### 2. Specify time format
+
+    # Call function passing only the year
+    o_utils.convert_date_to_iso("2020-01-02-03-04-56", time_format="%Y-%m-%d-%H-%M-%S")
+
+    # Returns
+    '2020-01-02T03:04:56Z'
+    """
+    if not isinstance(time_string, str):
+        raise TypeError("`time_string` must be a string.")
+    if not isinstance(time_format, str):
+        raise TypeError("`time_format` must be a string.")
+
+    try:
+        date = datetime.strptime(time_string,time_format)
+        date = datetime.strftime(date, "%Y-%m-%dT%H:%M:%S") + "Z"
+        return date
+
+    except ValueError:
+        raise ValueError(
+            f"`time_string` '{time_string}'"
+            f" does not match `time_format` '{time_format}'"
+            )

--- a/osometweet/utils.py
+++ b/osometweet/utils.py
@@ -98,6 +98,7 @@ def chunker(seq: list, size: int) -> list:
         raise ValueError("`seq` must be a list")
     return list(seq[pos:pos + size] for pos in range(0, len(seq), size))
 
+
 def convert_date_to_iso(time_string:str, time_format="%Y-%m-%d") -> str:
     """
     Convert input `time_string` to the iso format that Twitter
@@ -153,7 +154,7 @@ def convert_date_to_iso(time_string:str, time_format="%Y-%m-%d") -> str:
         raise TypeError("`time_format` must be a string.")
 
     try:
-        date = datetime.strptime(time_string,time_format)
+        date = datetime.strptime(time_string, time_format)
         date = datetime.strftime(date, "%Y-%m-%dT%H:%M:%S") + "Z"
         return date
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -231,6 +231,22 @@ class TestUtils(unittest.TestCase):
                 )
             self.assertEqual(resp, correct_resp)
 
+    ### Two tests for the convert_date_to_iso method ###
+    def test_convert_date_to_iso(self):
+        test_times = ["2020-01-01", "2020-01-02-03-04-56"]
+        test_formats = ["%Y-%m-%d","%Y-%m-%d-%H-%M-%S"]
+        correct_responses = [
+            '2020-01-01T00:00:00Z',
+            '2020-01-02T03:04:56Z'
+            ]
+        zipper = zip(test_times, test_formats, correct_responses)
+        for time, fmt, correct_resp in zipper:
+            resp = osometweet.utils.convert_date_to_iso(
+                time_string = time,
+                time_format = fmt
+                )
+            self.assertEqual(resp, correct_resp)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Remembering the format that Twitter wants time strings to be in for queries is a headache. 

I add `convert_date_to_iso` function in the `utils.py` module which makes this much easier. It can handle any `datetime` format input by the user. See the function's docstring for example usage.

Same as my previous PR, tests have not been run in the `test.py` (b/c I have reached my monthly data limit and the script breaks as a result) but pass locally. 

I also update some of the docstrings in the rest of the `utils.py` for consistency.

