### PR TITLE
add exception for streaming endpoints when rate_limit_manger=True

### DIFF
--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -913,6 +913,10 @@ class OsomeTweet:
         User fields included by default match the default parameters from
         twitter.
 
+        Note: Rate Limit Manager cannot be used with this endpoint. When
+        calling osometweet.OAuth2() for authorization, make sure to set the
+        `rate_limit_manager` value equal to `False`.
+
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/sampled-stream/introduction
 
         Parameters:
@@ -948,6 +952,10 @@ class OsomeTweet:
         User fields included by default match the default parameters from
         twitter.
 
+        Note: Rate Limit Manager cannot be used with this endpoint. When
+        calling osometweet.OAuth2() for authorization, make sure to set the
+        `rate_limit_manager` value equal to `False`.
+
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/sampled-stream/introduction
 
         Parameters:
@@ -967,6 +975,12 @@ class OsomeTweet:
         ----------
         - Exception
         """
+        if self._oauth._manage_rate_limits:
+            raise Exception(
+                "Rate Limit Manager cannot be used with streaming endpoints. "
+                "When calling osometweet.OAuth2(), make sure to set the "
+                "`rate_limit_manager` value equal to `False` and try again."
+            )
 
         payload = self._decorate_payload(
             payload=None,
@@ -1002,6 +1016,10 @@ class OsomeTweet:
         """
         Streams tweets that match the active streaming rules set by the user.
 
+        Note: Rate Limit Manager cannot be used with this endpoint. When
+        calling osometweet.OAuth2() for authorization, make sure to set the
+        `rate_limit_manager` value equal to `False`.
+
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/introduction
 
         Parameters:
@@ -1035,6 +1053,10 @@ class OsomeTweet:
         """
         Streams tweets that match the active streaming rules set by the user.
 
+        Note: Rate Limit Manager cannot be used with this endpoint. When
+        calling osometweet.OAuth2() for authorization, make sure to set the
+        `rate_limit_manager` value equal to `False`.
+
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/introduction
 
         Parameters:
@@ -1054,6 +1076,12 @@ class OsomeTweet:
         ----------
         - Exception
         """
+        if self._oauth._manage_rate_limits:
+            raise Exception(
+                "Rate Limit Manager cannot be used with streaming endpoints. "
+                "When calling osometweet.OAuth2(), make sure to set the "
+                "`rate_limit_manager` value equal to `False` and try again."
+            )
 
         payload = self._decorate_payload(
             payload=None,

--- a/osometweet/api.py
+++ b/osometweet/api.py
@@ -915,7 +915,7 @@ class OsomeTweet:
 
         Note: Rate Limit Manager cannot be used with this endpoint. When
         calling osometweet.OAuth2() for authorization, make sure to set the
-        `rate_limit_manager` value equal to `False`.
+        `manage_rate_limits` parameter equal to `False`.
 
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/sampled-stream/introduction
 
@@ -954,7 +954,7 @@ class OsomeTweet:
 
         Note: Rate Limit Manager cannot be used with this endpoint. When
         calling osometweet.OAuth2() for authorization, make sure to set the
-        `rate_limit_manager` value equal to `False`.
+        `manage_rate_limits` parameter equal to `False`.
 
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/sampled-stream/introduction
 
@@ -979,7 +979,7 @@ class OsomeTweet:
             raise Exception(
                 "Rate Limit Manager cannot be used with streaming endpoints. "
                 "When calling osometweet.OAuth2(), make sure to set the "
-                "`rate_limit_manager` value equal to `False` and try again."
+                "`manage_rate_limits` parameter equal to `False` and try again."
             )
 
         payload = self._decorate_payload(
@@ -1018,7 +1018,7 @@ class OsomeTweet:
 
         Note: Rate Limit Manager cannot be used with this endpoint. When
         calling osometweet.OAuth2() for authorization, make sure to set the
-        `rate_limit_manager` value equal to `False`.
+        `manage_rate_limits` parameter equal to `False`.
 
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/introduction
 
@@ -1055,7 +1055,7 @@ class OsomeTweet:
 
         Note: Rate Limit Manager cannot be used with this endpoint. When
         calling osometweet.OAuth2() for authorization, make sure to set the
-        `rate_limit_manager` value equal to `False`.
+        `manage_rate_limits` parameter equal to `False`.
 
         Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/introduction
 
@@ -1080,7 +1080,7 @@ class OsomeTweet:
             raise Exception(
                 "Rate Limit Manager cannot be used with streaming endpoints. "
                 "When calling osometweet.OAuth2(), make sure to set the "
-                "`rate_limit_manager` value equal to `False` and try again."
+                "`manage_rate_limits` value equal to `False` and try again."
             )
 
         payload = self._decorate_payload(


### PR DESCRIPTION
I tried to solve #84 based on the solution I included in that issue but this doesn't seem to work. The error is no longer thrown, however, the streaming endpoints stop working altogether (they just return nothing, I think there is some infinite loop going on).

I couldn't figure out exactly what the new issue was so instead reverted back to how things were and added an exception that throws when `rate_limit_manger=True`. I also added some details in the docstring to clarify that users can't use the rate limit manager with the streaming endpoints.

If you know why making the change I detailed in #84 would cause the above-described problems, please let me know. Otherwise, I think this solution is fine.